### PR TITLE
Add lobby and basic websocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # skydjo-app
+
+This repository contains a simple Expo client and a minimal Node.js server used for testing real-time features of the Skydjo game.
+
+## Getting started
+
+Install dependencies for both the client and the server:
+
+```bash
+cd Skydjo
+npm install
+cd ../server
+npm install
+```
+
+### Running the server
+
+```bash
+npm start
+```
+
+The server exposes a WebSocket endpoint on `ws://localhost:3001` and an HTTP endpoint `http://localhost:3001/history` returning chat history.
+
+### Running the Expo app
+
+In another terminal run:
+
+```bash
+cd Skydjo
+npx expo start
+```
+
+Open the Expo app on your device or simulator. A new **Lobby** tab is available to test socket communication.

--- a/Skydjo/app/(tabs)/_layout.tsx
+++ b/Skydjo/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="lobby"
+        options={{
+          title: 'Lobby',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.3.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/Skydjo/app/(tabs)/lobby.tsx
+++ b/Skydjo/app/(tabs)/lobby.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Button, FlatList, StyleSheet, TextInput } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { useLobby } from '@/hooks/useLobby';
+
+export default function LobbyScreen() {
+  const [name] = useState('Player-' + Math.floor(Math.random() * 1000));
+  const [text, setText] = useState('');
+  const { users, messages, sendChat } = useLobby(name);
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Lobby</ThemedText>
+      <ThemedText>Connected as {name}</ThemedText>
+      <ThemedText type="subtitle">Users</ThemedText>
+      <FlatList
+        data={users}
+        keyExtractor={(item) => item}
+        renderItem={({ item }) => <ThemedText>{item}</ThemedText>}
+        style={styles.list}
+      />
+      <ThemedText type="subtitle">Chat</ThemedText>
+      <FlatList
+        data={messages}
+        keyExtractor={(_, idx) => String(idx)}
+        renderItem={({ item }) => (
+          <ThemedText>
+            {item.user}: {item.text}
+          </ThemedText>
+        )}
+        style={styles.list}
+      />
+      <TextInput
+        value={text}
+        onChangeText={setText}
+        placeholder="Say something"
+        style={styles.input}
+      />
+      <Button
+        title="Send"
+        onPress={() => {
+          if (text.trim()) {
+            sendChat(text.trim());
+            setText('');
+          }
+        }}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  list: {
+    marginVertical: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#999',
+    padding: 8,
+    marginBottom: 8,
+  },
+});

--- a/Skydjo/hooks/useLobby.ts
+++ b/Skydjo/hooks/useLobby.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+
+export type ChatMessage = {
+  user: string;
+  text: string;
+};
+
+export function useLobby(name: string) {
+  const [users, setUsers] = useState<string[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const socket = new WebSocket('ws://localhost:3001');
+    socketRef.current = socket;
+
+    socket.onopen = () => {
+      socket.send(JSON.stringify({ type: 'join', name }));
+      fetch('http://localhost:3001/history')
+        .then((res) => res.json())
+        .then((history) => {
+          const chats = history.filter((e: any) => e.event === 'chat');
+          setMessages(
+            chats.map((c: any) => ({ user: c.user, text: c.message }))
+          );
+        })
+        .catch(() => {
+          // ignore errors fetching history
+        });
+    };
+
+    socket.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        if (data.type === 'users') {
+          setUsers(data.users);
+        } else if (data.type === 'chat') {
+          setMessages((m) => [...m, { user: data.user, text: data.message }]);
+        }
+      } catch {
+        // ignore bad payloads
+      }
+    };
+
+    return () => {
+      socket.close();
+    };
+  }, [name]);
+
+  const sendChat = (text: string) => {
+    if (socketRef.current?.readyState === WebSocket.OPEN) {
+      socketRef.current.send(
+        JSON.stringify({ type: 'chat', message: text })
+      );
+    }
+  };
+
+  return { users, messages, sendChat };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const http = require('http');
+const WebSocket = require('ws');
+
+const app = express();
+const server = http.createServer(app);
+const wss = new WebSocket.Server({ server });
+
+const lobby = {
+  users: [],
+  history: []
+};
+
+function broadcast(data) {
+  const msg = JSON.stringify(data);
+  wss.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
+  });
+}
+
+wss.on('connection', (ws) => {
+  let userId = null;
+
+  ws.on('message', (message) => {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch {
+      return;
+    }
+
+    if (data.type === 'join') {
+      userId = data.name;
+      lobby.users.push(userId);
+      lobby.history.push({ event: 'join', user: userId });
+      broadcast({ type: 'users', users: lobby.users });
+    } else if (data.type === 'chat') {
+      const record = { event: 'chat', user: userId, message: data.message };
+      lobby.history.push(record);
+      broadcast({ type: 'chat', user: userId, message: data.message });
+    }
+  });
+
+  ws.on('close', () => {
+    if (userId) {
+      lobby.users = lobby.users.filter((u) => u !== userId);
+      lobby.history.push({ event: 'leave', user: userId });
+      broadcast({ type: 'users', users: lobby.users });
+    }
+  });
+});
+
+app.get('/history', (req, res) => {
+  res.json(lobby.history);
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "skydjo-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add README instructions
- add lobby screen and WebSocket hook
- extend tab navigation
- create simple Node.js WebSocket server

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840104499948321a09165334a960d67